### PR TITLE
Simplify setup with Mars.run helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# mars
+# Mars
+
 Mult-Agentic Research System
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Create a `.env` file with your OpenAI key:
+
+```
+OPENAI_API_KEY=your-key-here
+```
+
+## Running
+
+Call the agent from Python:
+
+```python
+import mars
+mars.run()
+```
+
+This defaults to the query:
+
+```
+Find board members of top 10 S&P 500 companies by market cap.
+```
+
+You can pass a custom query:
+
+```python
+mars.run("your question")
+```
+

--- a/mars/__init__.py
+++ b/mars/__init__.py
@@ -1,0 +1,18 @@
+import os
+from dotenv import load_dotenv
+from openai import OpenAI
+
+def run(query: str | None = None):
+    """Run the Mars agent with a given query or the default example."""
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    client = OpenAI(api_key=api_key)
+    if not query:
+        query = (
+            "Find board members of top 10 S&P 500 companies by market cap.")
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": query}],
+    )
+    print(response.choices[0].message.content)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+python-dotenv


### PR DESCRIPTION
## Summary
- add simple `mars` package with `run()` helper
- read `.env` file for API keys
- document setup and example query for the agent

## Testing
- `python3 - <<'EOF'
import mars
try:
    mars.run()
except Exception as e:
    print('Error:', e)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684e428e6f3c832ea7d6a57af51ef995