### PR TITLE
Implement mars prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# mars
+# Mars
+
 Mult-Agentic Research System
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Create a `.env` file with your OpenAI key:
+
+```
+OPENAI_API_KEY=your-key-here
+```
+
+## Running
+
+Call the agent from Python:
+
+```python
+import mars
+mars.run()
+```
+
+This defaults to the query:
+
+```
+Find board members of top 10 S&P 500 companies by market cap.
+```
+
+You can pass a custom query:
+
+```python
+mars.run("your question")
+```
+

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,10 @@
+# Development Tasks
+
+This document breaks down the prototype implementation of **mars** into simple tasks.
+
+1. **Gateway API**: Build a FastAPI app that exposes a `/query` endpoint.
+2. **Orchestrator**: Create a class that assembles and runs `TaskEnvelope` objects.
+3. **Worker Pool**: Define a worker and runner abstraction. Provide an `EchoRunner` for demo.
+4. **CLI**: Implement a small `click` CLI with commands to run the gateway and a demo query.
+5. **Data Models**: Share `TaskEnvelope` and `ErrorEnvelope` using Pydantic models.
+6. **Demo**: Users can run `python -m mars.cli gateway` and send a query with the `demo` command.

--- a/mars/__init__.py
+++ b/mars/__init__.py
@@ -1,0 +1,18 @@
+import os
+from dotenv import load_dotenv
+from openai import OpenAI
+
+def run(query: str | None = None):
+    """Run the Mars agent with a given query or the default example."""
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    client = OpenAI(api_key=api_key)
+    if not query:
+        query = (
+            "Find board members of top 10 S&P 500 companies by market cap.")
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": query}],
+    )
+    print(response.choices[0].message.content)
+

--- a/mars/__init__.py
+++ b/mars/__init__.py
@@ -1,0 +1,5 @@
+from .models import TaskEnvelope, ErrorEnvelope
+from .gateway import app
+from .cli import cli
+
+__all__ = ["TaskEnvelope", "ErrorEnvelope", "app", "cli"]

--- a/mars/cli.py
+++ b/mars/cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import asyncio
+import click
+
+from .gateway import main as gateway_main
+
+
+@click.group()
+def cli() -> None:
+    """mars command line interface."""
+
+
+@cli.command()
+def gateway() -> None:
+    """Run the Gateway API."""
+    gateway_main()
+
+
+@cli.command()
+@click.argument("user_id")
+@click.argument("prompt_id")
+@click.argument("text")
+def demo(user_id: str, prompt_id: str, text: str) -> None:
+    """Run a demo query via Gateway."""
+    import requests
+
+    resp = requests.post(
+        "http://localhost:8000/query", params={"user_id": user_id, "prompt_id": prompt_id, "text": text}
+    )
+    print(resp.json())
+
+
+if __name__ == "__main__":
+    cli()

--- a/mars/gateway.py
+++ b/mars/gateway.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+
+from .models import TaskEnvelope
+from .worker import Worker, EchoRunner
+from .orchestrator import Orchestrator
+
+app = FastAPI(title="mars-gateway")
+
+runner = EchoRunner()
+worker = Worker(runner)
+orchestrator = Orchestrator(worker)
+
+
+@app.post("/query")
+async def query(user_id: str, prompt_id: str, text: str):
+    task = orchestrator.create_task(
+        user_id=user_id,
+        tool_context={},
+        prompt_template_id=prompt_id,
+        parameters={"text": text},
+    )
+    result = await orchestrator.run_task(task)
+    if "error_code" in result:
+        raise HTTPException(status_code=500, detail=result)
+    return result
+
+
+def main() -> None:
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/mars/models.py
+++ b/mars/models.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+
+class TaskEnvelope(BaseModel):
+    task_id: str
+    user_id: str
+    playbook_version: str
+    tool_context: Dict[str, Any]
+    prompt_template_id: str
+    parameters: Dict[str, Any]
+    memory_pointer: Optional[str] = None
+
+class ErrorEnvelope(BaseModel):
+    task_id: str
+    error_code: str
+    retryable: bool
+    details: Optional[str] = None

--- a/mars/orchestrator.py
+++ b/mars/orchestrator.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+from typing import Dict, Any
+
+from .models import TaskEnvelope, ErrorEnvelope
+
+
+class Orchestrator:
+    """Simplified orchestrator prototype."""
+
+    def __init__(self, worker: 'Worker') -> None:
+        self.worker = worker
+
+    def create_task(self, user_id: str, tool_context: Dict[str, Any], prompt_template_id: str, parameters: Dict[str, Any]) -> TaskEnvelope:
+        task = TaskEnvelope(
+            task_id=str(uuid.uuid4()),
+            user_id=user_id,
+            playbook_version="0.1.0",
+            tool_context=tool_context,
+            prompt_template_id=prompt_template_id,
+            parameters=parameters,
+        )
+        return task
+
+    async def run_task(self, task: TaskEnvelope) -> Dict[str, Any]:
+        try:
+            result = await self.worker.execute(task)
+            return {"task_id": task.task_id, "result": result}
+        except Exception as exc:
+            error = ErrorEnvelope(task_id=task.task_id, error_code="WORKER_ERROR", retryable=False, details=str(exc))
+            return error.dict()

--- a/mars/worker.py
+++ b/mars/worker.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from .models import TaskEnvelope
+
+
+class Worker:
+    """Simple worker that executes tasks using a runner."""
+
+    def __init__(self, runner: 'Runner') -> None:
+        self.runner = runner
+
+    async def execute(self, task: TaskEnvelope) -> Dict[str, Any]:
+        return await self.runner.run(task)
+
+
+class Runner:
+    """Base runner interface."""
+
+    async def run(self, task: TaskEnvelope) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class EchoRunner(Runner):
+    """Demo runner that echoes parameters."""
+
+    async def run(self, task: TaskEnvelope) -> Dict[str, Any]:
+        return {"echo": task.parameters}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+python-dotenv

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,12 @@
+from click.testing import CliRunner
+from mars.cli import cli
+
+
+def test_cli_demo(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "requests.post",
+        lambda url, params: type("Resp", (), {"json": lambda self=None: {"task_id": "1", "result": {"echo": params}}})(),
+    )
+    result = runner.invoke(cli, ["demo", "u1", "p1", "hi"])
+    assert result.exit_code == 0

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,13 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from mars.gateway import app
+
+client = TestClient(app)
+
+
+def test_query_endpoint():
+    resp = client.post("/query", params={"user_id": "u1", "prompt_id": "p1", "text": "hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "result" in data


### PR DESCRIPTION
## Summary
- outline tasks in docs
- implement a FastAPI gateway
- add an orchestrator and worker with an echo runner
- provide a simple CLI
- test the gateway endpoint and CLI

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e27a5e970832e9e570438de906856