### PR TITLE
Implement multi-agent research prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+memory.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # mars
-Mult-Agentic Research System
+
+Multi-Agentic Research System
+
+This repository contains a simple prototype implementation of a multi-agent research assistant written in Python. The system spawns subagents to perform web searches in parallel and synthesizes their results using a language model router.
+
+## Usage
+
+```bash
+pip install -r requirements.txt  # install dependencies
+python -m multi_agent_research.main
+```
+
+You will be prompted for a research question and the agents will attempt to produce a concise answer.
+
+### Search Provider
+
+By default the system uses DuckDuckGo for web search. To use the Tavily Search API instead, set the following environment variables:
+
+```bash
+export SEARCH_PROVIDER=tavily
+export TAVILY_API_KEY=your_api_key_here
+```
+
+DuckDuckGo will be used whenever `SEARCH_PROVIDER` is not set.

--- a/multi_agent_research/agent.py
+++ b/multi_agent_research/agent.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict
+
+from .tool import WebSearchTool
+from .memory import Memory
+from .utils import run_parallel, llm_route
+
+
+@dataclass
+class TaskResult:
+    task: str
+    summary: str
+
+
+class Subagent:
+    """Worker that executes a single research task."""
+
+    def __init__(self, task: str, memory: Memory | None = None):
+        self.task = task
+        self.memory = memory or Memory()
+        self.tools = [WebSearchTool()]
+
+    def run(self) -> TaskResult:
+        search_results = self.tools[0].run(self.task)
+        summary_prompt = (
+            f"Your task is: {self.task}."\
+            " Summarize the following search results in a concise paragraph:\n"\
+            f"{search_results}"
+        )
+        summary = llm_route(summary_prompt)
+        return TaskResult(task=self.task, summary=summary)
+
+
+class LeadResearcherAgent:
+    """Orchestrates research by spawning subagents and synthesizing results."""
+
+    def __init__(self, memory: Memory | None = None):
+        self.memory = memory or Memory()
+
+    def plan(self, query: str) -> List[str]:
+        prompt = (
+            "Given the question, break it into independent research tasks."\
+            f"\nQuestion: {query}"
+        )
+        tasks_text = llm_route(prompt)
+        tasks = [t.strip("- ") for t in tasks_text.splitlines() if t.strip()]
+        return tasks if tasks else [query]
+
+    def run(self, query: str) -> str:
+        tasks = self.plan(query)
+        self.memory.save("plan", tasks)
+
+        subagents = [Subagent(task, memory=self.memory) for task in tasks]
+        results: List[TaskResult] = run_parallel(lambda sa: sa.run(), subagents)
+        self.memory.save("results", [r.__dict__ for r in results])
+
+        synthesis = "".join(
+            f"Task: {r.task}\nSummary: {r.summary}\n" for r in results
+        )
+        final_prompt = (
+            f"Synthesize the following research results into a single answer to "
+            f"the question: {query}\n\n{synthesis}"
+        )
+        final_answer = llm_route(final_prompt)
+        self.memory.save("final_answer", final_answer)
+        return final_answer

--- a/multi_agent_research/evaluator.py
+++ b/multi_agent_research/evaluator.py
@@ -1,0 +1,9 @@
+from .utils import llm_route
+
+
+def evaluate_answer(answer: str) -> str:
+    prompt = (
+        "Score the following answer for completeness and quality on a scale of 1-5:"\
+        f"\n{answer}"
+    )
+    return llm_route(prompt)

--- a/multi_agent_research/main.py
+++ b/multi_agent_research/main.py
@@ -1,0 +1,12 @@
+from .agent import LeadResearcherAgent
+
+
+def main() -> None:
+    query = input("Enter your research question: ")
+    lead = LeadResearcherAgent()
+    answer = lead.run(query)
+    print("\nFinal Answer:\n", answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/multi_agent_research/memory.py
+++ b/multi_agent_research/memory.py
@@ -1,0 +1,28 @@
+import json
+import os
+from typing import Any, Dict
+
+
+class Memory:
+    """Simple file-backed key-value memory."""
+
+    def __init__(self, filepath: str = "memory.json"):
+        self.filepath = filepath
+        self._data: Dict[str, Any] = {}
+        if os.path.exists(self.filepath):
+            try:
+                with open(self.filepath, "r", encoding="utf-8") as f:
+                    self._data = json.load(f)
+            except Exception:
+                self._data = {}
+
+    def save(self, key: str, value: Any) -> None:
+        self._data[key] = value
+        try:
+            with open(self.filepath, "w", encoding="utf-8") as f:
+                json.dump(self._data, f, indent=2)
+        except Exception:
+            pass
+
+    def load(self, key: str) -> Any:
+        return self._data.get(key)

--- a/multi_agent_research/tool.py
+++ b/multi_agent_research/tool.py
@@ -1,0 +1,63 @@
+import os
+import requests
+from typing import List, Optional, Dict
+
+
+class Tool:
+    name: str = "base"
+    description: str = ""
+
+    def run(self, query: str) -> str:
+        raise NotImplementedError
+
+
+class WebSearchTool(Tool):
+    name = "web_search"
+    description = "Perform a web search and return text snippets"
+
+    def __init__(
+        self,
+        provider: Optional[str] = None,
+        duckduckgo_url: str | None = None,
+        tavily_url: str | None = None,
+        tavily_api_key: str | None = None,
+    ):
+        self.provider = provider or os.getenv("SEARCH_PROVIDER", "duckduckgo")
+        self.duckduckgo_url = (
+            duckduckgo_url or "https://duckduckgo.com/?q={query}&t=h_&ia=web"
+        )
+        self.tavily_url = tavily_url or "https://api.tavily.com/search"
+        self.tavily_api_key = tavily_api_key or os.getenv("TAVILY_API_KEY")
+
+    def _duckduckgo_search(self, query: str) -> str:
+        url = self.duckduckgo_url.format(query=query)
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        return resp.text[:1000]
+
+    def _tavily_search(self, query: str) -> str:
+        if not self.tavily_api_key:
+            raise ValueError("TAVILY_API_KEY not set")
+        params: Dict[str, str] = {
+            "api_key": self.tavily_api_key,
+            "query": query,
+            "search_depth": "basic",
+        }
+        resp = requests.get(self.tavily_url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        results = data.get("results") or []
+        snippets = []
+        for r in results[:3]:
+            title = r.get("title", "")
+            content = r.get("content", "")
+            snippets.append(f"{title}: {content}")
+        return "\n".join(snippets)
+
+    def run(self, query: str) -> str:
+        try:
+            if self.provider == "tavily":
+                return self._tavily_search(query)
+            return self._duckduckgo_search(query)
+        except Exception as e:
+            return f"Search error: {e}"

--- a/multi_agent_research/utils.py
+++ b/multi_agent_research/utils.py
@@ -1,0 +1,23 @@
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, Iterable, List
+import os
+
+
+def run_parallel(func: Callable[[any], any], items: Iterable[any]) -> List[any]:
+    with ThreadPoolExecutor() as executor:
+        return list(executor.map(func, items))
+
+
+def llm_route(prompt: str, provider: str | None = None) -> str:
+    provider = provider or os.getenv("LLM_PROVIDER", "stub")
+    if provider == "openai" and os.getenv("OPENAI_API_KEY"):
+        try:
+            import openai
+            resp = openai.ChatCompletion.create(
+                model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return resp.choices[0].message.content.strip()
+        except Exception as e:
+            return f"OpenAI error: {e}"
+    return f"[Stubbed LLM response] {prompt[:200]}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+requests


### PR DESCRIPTION
## Summary
- prototype Python package `multi_agent_research` with simple LeadResearcher and Subagent agents
- implement rudimentary memory store and tool interface
- provide LLM routing helper with OpenAI support and stub fallback
- add command line entry point and basic evaluator
- document usage and add requirements
- add option for Tavily search API

## Testing
- `pip install -r requirements.txt`
- `python -m multi_agent_research.main <<EOF`
  `What is the capital of France?`
  `EOF`


------
https://chatgpt.com/codex/tasks/task_e_684e29495744832ea036e66a19289ea3